### PR TITLE
apply overlap checking for stacko

### DIFF
--- a/src/js/scene.js
+++ b/src/js/scene.js
@@ -3,7 +3,7 @@ import GameState from './gameState.js';
 import Shapes from './shapes.js';
 import { createRandomShapesCenter, solidifyStacko } from './shapeManager.js';
 import { createRaycastBetween } from './raycastUtils.js';
-import { triggerGameOver, restartGame } from './gameOverManager.js';
+import { triggerGameOver /*, restartGame*/ } from './gameOverManager.js';
 // import { checkOverlapWithGround } from './utils.js';
 
 export class MainScene extends Phaser.Scene {


### PR DESCRIPTION
try apply overlap checking to each stacko in shapeManager.js

there's still a bug on first placement for each stacko also comments out an unused func in scene.js though

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents pieces from overlapping when dropped; placement now respects occupied cells and snaps to the nearest valid grid position.
  - Improves drag accuracy and responsiveness; if a move would collide, the piece returns to its last valid position.
  - Enhances ghost/preview block behavior to reflect valid placement in real time, reducing accidental invalid placements and improving clarity during drag-and-drop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->